### PR TITLE
Server start/stop on package activate/deactivate

### DIFF
--- a/lib/linter-languagetool.coffee
+++ b/lib/linter-languagetool.coffee
@@ -55,7 +55,6 @@ module.exports = LinterLanguagetool =
     @provider = new LinterProvider()
 
   deactivate: ->
-    console.log("Called destroy in linter-languagetool.coffee")
     @provider.destroy()
     @provider = null
 

--- a/lib/linter-languagetool.coffee
+++ b/lib/linter-languagetool.coffee
@@ -5,6 +5,11 @@ module.exports = LinterLanguagetool =
       description: 'If given, the linter tries to start a local languagetool server and connect to it. If left blank, the public languagetool API is used instead.'
       type: 'string'
       default: ''
+    languagetoolServerPort:
+      title: 'Port for local languagetool-server.jar'
+      description: 'Sets the port on which the local languagetool server will listen.'
+      type: 'number'
+      default: 8081
     configFilePath:
       title: 'Path to a config file'
       description: 'Path to a configuration file for the LanguageTool server. Can be used to provide the path to the n-gram data to LanugageTool. If given, LanguageTool can detect errors with words that are often confused, like *their* and *there*. See [LanguageTool Wiki](http://wiki.languagetool.org/finding-errors-using-n-gram-data) for more information'

--- a/lib/linter-languagetool.coffee
+++ b/lib/linter-languagetool.coffee
@@ -1,4 +1,7 @@
+LinterProvider = require './linter-provider'
+
 module.exports = LinterLanguagetool =
+  provider: null
   config:
     languagetoolServerPath:
       title: 'Path to local languagetool-server.jar'
@@ -48,13 +51,20 @@ module.exports = LinterLanguagetool =
       description: 'If enabled the linter will run on every change on the file.'
       default: false
 
+  activate: ->
+    @provider = new LinterProvider()
+
+  deactivate: ->
+    console.log("Called destroy in linter-languagetool.coffee")
+    @provider.destroy()
+    @provider = null
+
   provideLinter: ->
-    LinterProvider = require './linter-provider'
-    provider = new LinterProvider()
+    # provider = new LinterProvider()
     return {
       name: 'languagetool'
       scope: 'file'
       lintsOnChange: atom.config.get 'linter-languagetool.lintsOnChange'
       grammarScopes: atom.config.get 'linter-languagetool.grammerScopes'
-      lint: provider.lint
+      lint: @provider.lint
     }

--- a/lib/linter-provider.coffee
+++ b/lib/linter-provider.coffee
@@ -39,6 +39,8 @@ module.exports = class LinterProvider
       ltoptions = ''
       if atom.config.get 'linter-languagetool.configFilePath'
         ltoptions = ltoptions + ' --config ' + atom.config.get 'linter-languagetool.configFilePath'
+      if atom.config.get 'linter-languagetool.languagetoolServerPort'
+        ltoptions = ltoptions + ' --port ' + atom.config.get 'linter-languagetool.languagetoolServerPort'
       ltjar = atom.config.get 'linter-languagetool.languagetoolServerPath'
       ltserver = child_process.exec 'java -cp ' + ltjar + ' org.languagetool.server.HTTPServer ' + ltoptions +  ' "$@" ', (error, stdout, stderr) ->
         if error
@@ -64,7 +66,7 @@ module.exports = class LinterProvider
         lthostname = 'localhost'
         http = require('http')
         apipath = '/v2'
-        ltport = 8081
+        ltport = atom.config.get 'linter-languagetool.languagetoolServerPort'
       else
         http = require('https')
         apipath = '/api/v2'

--- a/lib/linter-provider.coffee
+++ b/lib/linter-provider.coffee
@@ -1,7 +1,5 @@
 child_process = require 'child_process'
 querystring = require 'querystring'
-net = require 'net'
-{Disposable} = require 'atom'
 
 module.exports = class LinterProvider
   ltserver: null


### PR DESCRIPTION
Closes #19 - I added activate / deactivate to linter-language (per [Standard Linter v2 spec](http://steelbrain.me/linter/examples/standard-linter-v2.html)). On activate a new LinterProvider is constructed, and the server is started within the constructor. On deactivate, provider.destroy() is called, which cleans up the running process.

I also added a config option for the port, defaults to the default for LanguageTool. I have two machines where port 8081 is already in use and figured I might not be the only one with this conflict.