### PR TITLE
Option for setting custom url for LanguageTool server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
 os:
   - linux
   - osx
+  
+install:
+  - if [ $TRAVIS_OS_NAME = osx ]; then brew install languagetool; fi
 
 ### Generic setup follows ###
 script:

--- a/lib/linter-languagetool.coffee
+++ b/lib/linter-languagetool.coffee
@@ -42,6 +42,13 @@ module.exports = LinterLanguagetool =
       type: 'boolean'
       description: 'If enabled the linter will run on every change on the file.'
       default: false
+      
+  activate: ->
+    lthelper = require './ltserver-helper'
+    
+  deactivate: ->
+    lthelper = require './ltserver-helper'
+    lthelper.destroy()
 
   provideLinter: ->
     LinterProvider = require './linter-provider'

--- a/lib/linter-languagetool.coffee
+++ b/lib/linter-languagetool.coffee
@@ -1,3 +1,5 @@
+{CompositeDisposable} = require 'atom'
+
 module.exports = LinterLanguagetool =
   config:
     languagetoolServerPath:
@@ -48,11 +50,27 @@ module.exports = LinterLanguagetool =
       default: false
       
   activate: ->
+    @subscriptions = new CompositeDisposable()
     lthelper = require './ltserver-helper'
+    LTInfoView = require './lt-status-view'
+    @ltInfo = new LTInfoView()
     
+  
   deactivate: ->
     lthelper = require './ltserver-helper'
-    lthelper.destroy()
+    lthelper?.destroy()
+    
+    @ltInfo?.destroy()
+    @ltInfo = null
+    
+    @statusBarTile?.destroy()
+    @statusBarTile = null
+    
+    @subscriptions?.dispose()
+    @subscriptions = null
+    
+  consumeStatusBar: (statusBar) ->
+    @statusBarTile = statusBar.addRightTile(item: @ltInfo.element, priority: 400)
 
   provideLinter: ->
     LinterProvider = require './linter-provider'

--- a/lib/linter-languagetool.coffee
+++ b/lib/linter-languagetool.coffee
@@ -16,6 +16,11 @@ module.exports = LinterLanguagetool =
       description: 'Path to a configuration file for the LanguageTool server. Can be used to provide the path to the n-gram data to LanugageTool. If given, LanguageTool can detect errors with words that are often confused, like *their* and *there*. See [LanguageTool Wiki](http://wiki.languagetool.org/finding-errors-using-n-gram-data) for more information'
       type: 'string'
       default: ''
+    languagetoolServerPort:
+      title: 'Port for local languagetool-server.jar'
+      description: 'Sets the port on which the local languagetool server will listen.'
+      type: 'number'
+      default: 8081
     grammerScopes:
       type: 'array'
       description: 'This preference holds a list of grammar scopes languagetool should be applied to.'

--- a/lib/linter-languagetool.coffee
+++ b/lib/linter-languagetool.coffee
@@ -52,6 +52,7 @@ module.exports = LinterLanguagetool =
   activate: ->
     @subscriptions = new CompositeDisposable()
     lthelper = require './ltserver-helper'
+    lthelper.init()
     LTInfoView = require './lt-status-view'
     @ltInfo = new LTInfoView()
     

--- a/lib/linter-languagetool.coffee
+++ b/lib/linter-languagetool.coffee
@@ -1,10 +1,14 @@
 module.exports = LinterLanguagetool =
   config:
     languagetoolServerPath:
-      title: 'Path to local languagetool-server.jar'
-      description: 'If given, the linter tries to start a local languagetool server and connect to it. If left blank, the public languagetool API is used instead.'
+      title: 'URL of the Languagetool server or path to your local languagetool-server.jar'
+      description: """Set the URL of your Languagetool server.
+        It defaults to the public Languagetool server API.
+        If you give the path to your local languagetool-server.jar,
+        linter tries to start the local languagetool server and connect to it."""
       type: 'string'
-      default: ''
+      default: 'https://languagetool.org/api/'
+      order: 1
     configFilePath:
       title: 'Path to a config file'
       description: 'Path to a configuration file for the LanguageTool server. Can be used to provide the path to the n-gram data to LanugageTool. If given, LanguageTool can detect errors with words that are often confused, like *their* and *there*. See [LanguageTool Wiki](http://wiki.languagetool.org/finding-errors-using-n-gram-data) for more information'

--- a/lib/linter-provider.coffee
+++ b/lib/linter-provider.coffee
@@ -93,7 +93,6 @@ module.exports = class LinterProvider
       if not lthelper.ltinfo
         # Disable the linter if the server is not repoinding
         resolve([])
-        return
       
       post_data = getPostDataDict(TextEditor.getText())
       

--- a/lib/linter-provider.coffee
+++ b/lib/linter-provider.coffee
@@ -31,6 +31,23 @@ module.exports = class LinterProvider
     'TYPOS': 'error'
     'WIKIPEDIA': 'info'
   }
+  
+  getPostDataDict= (editorContent) ->
+    
+    post_data_dict = {
+      'language': 'auto'
+      'text': editorContent
+      'motherTongue': atom.config.get 'linter-languagetool.motherTongue'
+    }
+    
+    if (atom.config.get 'linter-languagetool.preferredVariants').length > 0
+      post_data_dict['preferredVariants'] = atom.config.get('linter-languagetool.preferredVariants').join()
+    if (atom.config.get 'linter-languagetool.disabledCategories').length > 0
+      post_data_dict['disabledCategories'] = atom.config.get('linter-languagetool.disabledCategories').join()
+    if (atom.config.get 'linter-languagetool.disabledRules').length > 0
+      post_data_dict['disabledRules'] = atom.config.get('linter-languagetool.disabledRules').join()
+      
+    return post_data_dict
 
   lint: (TextEditor) ->
     new Promise (Resolve) ->
@@ -52,20 +69,7 @@ module.exports = class LinterProvider
         lthostname = 'languagetool.org'
         ltport = 443
 
-      post_data_dict = {
-        'language': 'auto'
-        'text': editorContent
-        'motherTongue': atom.config.get 'linter-languagetool.motherTongue'
-      }
-
-      if (atom.config.get 'linter-languagetool.preferredVariants').length > 0
-        post_data_dict['preferredVariants'] = atom.config.get('linter-languagetool.preferredVariants').join()
-      if (atom.config.get 'linter-languagetool.disabledCategories').length > 0
-        post_data_dict['disabledCategories'] = atom.config.get('linter-languagetool.disabledCategories').join()
-      if (atom.config.get 'linter-languagetool.disabledRules').length > 0
-        post_data_dict['disabledRules'] = atom.config.get('linter-languagetool.disabledRules').join()
-
-      post_data = querystring.stringify post_data_dict
+      post_data = querystring.stringify getPostDataDict(editorContent)
 
       options = {
         hostname: lthostname

--- a/lib/linter-provider.coffee
+++ b/lib/linter-provider.coffee
@@ -3,7 +3,6 @@ querystring = require 'querystring'
 
 
 module.exports = class LinterProvider
-  server_started = false
   categries_map = {
     'CASING': 'error'
     'COLLOCATIONS': 'error'
@@ -33,23 +32,6 @@ module.exports = class LinterProvider
     'WIKIPEDIA': 'info'
   }
 
-  startserver = ->
-    if server_started is false
-      server_started = true
-      ltoptions = ''
-      if atom.config.get 'linter-languagetool.configFilePath'
-        ltoptions = ltoptions + ' --config ' + atom.config.get 'linter-languagetool.configFilePath'
-      ltjar = atom.config.get 'linter-languagetool.languagetoolServerPath'
-      ltserver = child_process.exec 'java -cp ' + ltjar + ' org.languagetool.server.HTTPServer ' + ltoptions +  ' "$@" ', (error, stdout, stderr) ->
-        if error
-          console.error error
-        console.log stdout
-        console.log stderr
-
-        ltserver.stdout.on 'data', (data) ->
-          console.log data
-
-
   lint: (TextEditor) ->
     new Promise (Resolve) ->
       received = ""
@@ -60,7 +42,6 @@ module.exports = class LinterProvider
       textBuffer = TextEditor.getBuffer()
 
       if atom.config.get 'linter-languagetool.languagetoolServerPath'
-        startserver()
         lthostname = 'localhost'
         http = require('http')
         apipath = '/v2'

--- a/lib/linter-provider.coffee
+++ b/lib/linter-provider.coffee
@@ -90,6 +90,11 @@ module.exports = class LinterProvider
   lint: (TextEditor) ->
     
     new Promise (resolve) ->
+      if not lthelper.ltinfo
+        # Disable the linter if the server is not repoinding
+        resolve([])
+        return
+      
       post_data = getPostDataDict(TextEditor.getText())
       
       options = {

--- a/lib/lt-status-view.coffee
+++ b/lib/lt-status-view.coffee
@@ -1,0 +1,33 @@
+module.exports =
+class LTStatusView
+  constructor: ->
+    @viewUpdatePending = false
+    
+    @element = document.createElement('status-bar-lt-server-info')
+    @element.classList.add('lt-server-info', 'inline-block', 'hide')
+    @logo = document.createElement('a')
+    @logo.textContent = 'LT'
+    @element.appendChild(@logo)
+    
+    lthelper = require './ltserver-helper'
+    @subscription = lthelper.onDidChangeLTInfo ( (info) =>
+      @update(info)
+    )
+    
+    @tooltip = atom.tooltips.add(@element, title: => "#{@info.name} Version: #{@info.version} (#{@info.buildDate})")
+    
+  destroy: ->
+    @tooltip.dispose()
+    @subscription.dispose
+        
+  update: (info) ->
+    return if @viewUpdatePending
+    console.log(info)
+    @viewUpdatePending = true
+    @updateSubscription = atom.views.updateDocument =>
+      @viewUpdatePending = false
+      @info = info
+      if @info
+        @element.classList.remove('hide')
+      else
+        @element.classList.add('hide')

--- a/lib/lt-status-view.coffee
+++ b/lib/lt-status-view.coffee
@@ -22,7 +22,6 @@ class LTStatusView
         
   update: (info) ->
     return if @viewUpdatePending
-    console.log(info)
     @viewUpdatePending = true
     @updateSubscription = atom.views.updateDocument =>
       @viewUpdatePending = false

--- a/lib/ltserver-helper.coffee
+++ b/lib/ltserver-helper.coffee
@@ -1,0 +1,48 @@
+{BufferedProcess, CompositeDisposable} = require 'atom'
+
+class LTServerHelper
+  
+  constructor: ->
+    @disposables = new CompositeDisposable
+    @ltserver = undefined
+    if atom.config.get 'linter-languagetool.languagetoolServerPath'
+      @startserver()
+    
+    # Register for LanguageServer Settings Changes
+    @disposables.add atom.config.onDidChange 'linter-languagetool.languagetoolServerPath', ({newValue, oldValue}) =>
+      if newValue
+        @stopserver()
+        @startserver()
+      else
+        @stopserver()
+        
+    @disposables.add atom.config.onDidChange 'linter-languagetool.configFilePath', ({newValue, oldValue}) =>
+      @stopserver()
+      @startserver()
+  
+  destroy: ->
+    @stopserver()
+    @disposables.dispose()
+  
+  startserver: ->
+    ltoptions = ''
+    if atom.config.get 'linter-languagetool.configFilePath'
+      ltoptions = ltoptions + ' --config ' + atom.config.get 'linter-languagetool.configFilePath'
+    ltjar = atom.config.get 'linter-languagetool.languagetoolServerPath'
+       
+    command = 'java'
+    if process.platform is 'win32'
+      command = 'javaw'
+       
+    @ltserver = new BufferedProcess({
+      command: command
+      args: ['-cp', ltjar, 'org.languagetool.server.HTTPServer', ltoptions]
+      options:
+        detached: true,
+        stdio: 'ignore'
+    })
+     
+  stopserver: ->
+    @ltserver?.kill()
+    
+module.exports = new LTServerHelper()

--- a/lib/ltserver-helper.coffee
+++ b/lib/ltserver-helper.coffee
@@ -5,6 +5,8 @@ class LTServerHelper
   constructor: ->
     @disposables = new CompositeDisposable
     @ltserver = undefined
+    @url = 'https://languagetool.org/api/v2/check'
+    
     if atom.config.get 'linter-languagetool.languagetoolServerPath'
       @startserver()
     
@@ -41,8 +43,11 @@ class LTServerHelper
         detached: true,
         stdio: 'ignore'
     })
+    
+    @url = 'http://localhost:8081/v2/check'
      
   stopserver: ->
     @ltserver?.kill()
+    @url = 'https://languagetool.org/api/v2/check'
     
 module.exports = new LTServerHelper()

--- a/lib/ltserver-helper.coffee
+++ b/lib/ltserver-helper.coffee
@@ -60,7 +60,7 @@ class LTServerHelper
             atom.notifications.addError("""The public languagetool server is
               not responding. The linter will be disabled.""",
               {detail: err.message})
-            reject(err)        
+            reject(err)
           )
       )
     )

--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
   "engines": {
     "atom": ">=1.4.0 <2.0.0"
   },
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^1.0.0": "consumeStatusBar"
+      }
+    }
+},
   "providedServices": {
     "linter": {
       "versions": {

--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
         "2.0.0": "provideLinter"
       }
     }
+  },
+  "dependencies": {
+    "request": "^2.83.0",
+    "request-promise-native": "^1.0.5"
   }
 }

--- a/spec/linter-languagetool-spec.js
+++ b/spec/linter-languagetool-spec.js
@@ -1,11 +1,20 @@
 "use babel";
 
+
 describe('The languagetool-linter for AtomLinter', () => {
   const lint = require('../lib/linter-languagetool').provideLinter().lint;
-
+  const lthelper = require('../lib/ltserver-helper')
+  
   beforeEach(() => {
     waitsForPromise(() => {
       return atom.packages.activatePackage("linter-languagetool");
+    });
+    waitsForPromise(() => {
+      return new Promise( (resolve) => {
+          lthelper.onDidChangeLTInfo(() => {
+              resolve()
+          });
+      });
     });
   });
 

--- a/spec/ltserver-helper-spec.js
+++ b/spec/ltserver-helper-spec.js
@@ -44,6 +44,28 @@ if (process.platform === 'darwin') {
     });    
   });
   
+  describe('When the local jar and port is given', () => {
+    
+    beforeEach(() => {
+      atom.config.set('linter-languagetool.languagetoolServerPath','/usr/local/Cellar/languagetool/3.9/libexec/languagetool-server.jar')
+      atom.config.set('linter-languagetool.languagetoolServerPort',8085)
+      waitsForPromise(() => {
+        return lthelper.init()
+      });
+    });
+    
+    afterEach(() => {
+        lthelper.destroy()
+    });
+          
+    it('it starts the service on the given port', () => {
+      expect(lthelper.ltserver).toBeDefined();
+      expect(lthelper.ltserver.process).toBeDefined();
+      expect(lthelper.url).toEqual('http://localhost:8085/v2/check');
+      expect(lthelper.ltinfo).toBeDefined();
+    });    
+  });
+  
   describe('When the local path not exists', () => {
     
     beforeEach(() => {

--- a/spec/ltserver-helper-spec.js
+++ b/spec/ltserver-helper-spec.js
@@ -1,0 +1,122 @@
+"use babel";
+const { spawn } = require('child_process');
+const lthelper = require('../lib/ltserver-helper')
+
+describe('The LanguageServer Helper Module', () => {
+ 
+  beforeEach(() => {
+    waitsForPromise(() => {
+      return lthelper.init()
+    });
+  });
+  
+  afterEach(() => {
+      lthelper.destroy()
+  });
+  
+  it('connects by default to the public server', () => {
+    expect(lthelper.url).toEqual('https://languagetool.org/api/v2/check');
+    expect(lthelper.ltinfo).toBeDefined();
+  });
+});
+
+// Test the local servers only on mac os because there we can install langugeetool
+// on travis
+if (process.platform === 'darwin') {
+  describe('When the local jar is given', () => {
+    
+    beforeEach(() => {
+      atom.config.set('linter-languagetool.languagetoolServerPath','/usr/local/Cellar/languagetool/3.9/libexec/languagetool-server.jar')
+      waitsForPromise(() => {
+        return lthelper.init()
+      });
+    });
+    
+    afterEach(() => {
+        lthelper.destroy()
+    });
+          
+    it('it starts the service', () => {
+      expect(lthelper.ltserver).toBeDefined();
+      expect(lthelper.ltserver.process).toBeDefined();
+      expect(lthelper.url).toEqual('http://localhost:8081/v2/check');
+      expect(lthelper.ltinfo).toBeDefined();
+    });    
+  });
+  
+  describe('When the local path not exists', () => {
+    
+    beforeEach(() => {
+      atom.config.set('linter-languagetool.languagetoolServerPath','/languagetool-server.jar')
+      waitsForPromise(() => {
+        return lthelper.init();
+      });
+    });
+    
+    afterEach(() => {
+        lthelper.destroy();
+    });
+          
+    it('it shows a warning and uses the public server', () => {
+      noti = atom.notifications.getNotifications();
+      expect(noti[0].type).toEqual("warning");    
+      expect(lthelper.url).toEqual('https://languagetool.org/api/v2/check');
+      expect(lthelper.ltinfo).toBeDefined();
+    });    
+  });
+  
+  describe('When a custom url is given', () => {
+  let process;          
+    
+    beforeEach(() => {
+      waitsForPromise(() => {
+        return new Promise( (resolve) => {
+          process = spawn('/usr/local/bin/languagetool-server',
+            ['-p','8082']);
+          process.stdout.on('data', (data) => {
+              if (/Server started/.test(data)) {
+                resolve()
+              }
+          });
+        });
+      });
+      
+      atom.config.set('linter-languagetool.languagetoolServerPath','http://localhost:8082')
+      waitsForPromise(() => {
+        return lthelper.init()
+      });
+    });
+    
+    afterEach(() => {
+        lthelper.destroy()
+        process.kill();
+    });
+          
+    it('it uses the given url', () => {
+      expect(lthelper.url).toEqual('http://localhost:8082/v2/check');
+      expect(lthelper.ltinfo).toBeDefined();
+    });    
+  });
+  
+  describe('When the custom url is not responding', () => {
+          
+    beforeEach(() => { 
+      atom.config.set('linter-languagetool.languagetoolServerPath','http://localhost:8082')
+      waitsForPromise(() => {
+        return lthelper.init()
+      });
+    });
+    
+    afterEach(() => {
+        lthelper.destroy()
+    });
+          
+    it('it shows a warning and uses the public server', () => {
+      noti = atom.notifications.getNotifications();
+      expect(noti[0].type).toEqual("warning");    
+      expect(lthelper.url).toEqual('https://languagetool.org/api/v2/check');
+      expect(lthelper.ltinfo).toBeDefined();
+    });     
+  });
+}
+  

--- a/styles/linter-languagetool.less
+++ b/styles/linter-languagetool.less
@@ -1,0 +1,8 @@
+@import "ui-variables";
+
+.lt-server-info a,
+.lt-server-info a:hover {
+  color: @text-color;
+  text-decoration: underline; 
+  text-decoration-style: wavy; 
+}

--- a/styles/linter-languagetool.less
+++ b/styles/linter-languagetool.less
@@ -1,8 +1,18 @@
 @import "ui-variables";
 
+.wavy_border(@color) {
+  background-image:
+    linear-gradient(45deg, transparent 65%, @color 80%, transparent 90%),
+    linear-gradient(135deg, transparent 5%, @color 15%, transparent 25%),
+    linear-gradient(135deg, transparent 45%, @color 55%, transparent 65%),
+    linear-gradient(45deg, transparent 25%, @color 35%, transparent 50%);
+  background-size: 8px 2px;
+  background-repeat: repeat-x;
+  background-position: left bottom;
+}
+
 .lt-server-info a,
 .lt-server-info a:hover {
   color: @text-color;
-  text-decoration: underline; 
-  text-decoration-style: wavy; 
+  .wavy_border(@background-color-info);
 }


### PR DESCRIPTION
This pull request add this features:
* allow to define a custom url for the LanguageTool server (e.g. if the server is running as local service)
* start and stop the user defined server on package activation and deactivation and on configuration changes (e.g. change of the config file path) - Fixes (#19)
* lint only the document if the server is reachable
* if the local server can not be started or the custom url is not reachable the linter falls back to the public server
* shows the version and build date of the server in the status bar
* option  to set the port of the local server
* some tests for the local server for osx