### PR TITLE
Correctly pick up config file

### DIFF
--- a/lib/ltserver-helper.coffee
+++ b/lib/ltserver-helper.coffee
@@ -65,6 +65,12 @@ class LTServerHelper
               {detail: err.message})
             reject(err)
           )
+        else
+          atom.notifications.addError("""There is some problem with your
+            langugetool server. The linter will not use the public url and
+            hence might not work correctly.""",
+            {detail: err.message})
+          reject(err)
       )
     )
 
@@ -140,13 +146,16 @@ class LTServerHelper
     if atom.config.get 'linter-languagetool.configFilePath'
       args.push ['--config', atom.config.get 'linter-languagetool.configFilePath']...
 
-    return new Promise( (resolve) =>
+    return new Promise( (resolve, reject) =>
       stdout = (output) ->
         if /Server started/.test(output)
           resolve()
+      stderr = (output) ->
+
       exit = (output) ->
-        # Usually a port error, thus an other server is already running
-        resolve()
+        # Can be a for example port errors, if another server is already running
+        # or config file not found errors.
+        reject()
 
       @ltserver = new BufferedProcess({
         command: command
@@ -154,6 +163,7 @@ class LTServerHelper
         options:
           detached: true
         stdout: stdout
+        stderr: stderr
         exit: exit
       })
     )

--- a/lib/ltserver-helper.coffee
+++ b/lib/ltserver-helper.coffee
@@ -126,9 +126,6 @@ class LTServerHelper
       )
 
   startserver: (port = 8081) ->
-    ltoptions = ''
-    if atom.config.get 'linter-languagetool.configFilePath'
-      ltoptions = ltoptions + ' --config ' + atom.config.get 'linter-languagetool.configFilePath'
     ltjar = atom.config.get 'linter-languagetool.languagetoolServerPath'
 
     command = 'java'
@@ -138,6 +135,10 @@ class LTServerHelper
     jvmoptions = []
     if atom.config.get 'linter-languagetool.jvmOptions'
       jvmoptions = [atom.config.get 'linter-langugetool.jvmOptions']
+
+    args = jvmoptions.concat ['-cp', ltjar, 'org.languagetool.server.HTTPServer', '--port', port]
+    if atom.config.get 'linter-languagetool.configFilePath'
+      args.push ['--config', atom.config.get 'linter-languagetool.configFilePath']...
 
     return new Promise( (resolve) =>
       stdout = (output) ->
@@ -149,7 +150,7 @@ class LTServerHelper
 
       @ltserver = new BufferedProcess({
         command: command
-        args: jvmoptions.concat ['-cp', ltjar, 'org.languagetool.server.HTTPServer', '--port', port, ltoptions]
+        args: args
         options:
           detached: true
         stdout: stdout

--- a/spec/linter-languagetool-spec.js
+++ b/spec/linter-languagetool-spec.js
@@ -48,7 +48,7 @@ describe('The languagetool-linter for AtomLinter', () => {
           expect(messages[0].severity).toBeDefined();
           expect(messages[0].severity).toEqual('error');
           expect(messages[0].excerpt).toBeDefined();
-          expect(messages[0].excerpt).toEqual('Spelling mistake');
+          expect(messages[0].excerpt).toEqual("Possible spelling mistake. 'colored' is American English.");
           expect(messages[0].location.file).toBeDefined();
           expect(messages[0].location.file).toMatch(/.+languagetool-hp-test\.txt$/);
           expect(messages[0].location.position).toBeDefined();

--- a/spec/ltserver-helper-spec.js
+++ b/spec/ltserver-helper-spec.js
@@ -142,4 +142,60 @@ if (process.platform === 'darwin') {
       expect(lthelper.ltinfo).toBeDefined();
     });
   });
+
+  describe('When the local jar and a config file is given', () => {
+
+    beforeEach(() => {
+      atom.config.set(
+        'linter-languagetool.languagetoolServerPath',
+        '/usr/local/Cellar/languagetool/4.5/libexec/languagetool-server.jar'
+      )
+
+      atom.config.set(
+        'linter-languagetool.configFilePath',
+        __dirname + '/test_files/sample_languagetool.cfg'
+      )
+
+      waitsForPromise(() => {
+        return lthelper.init()
+      });
+    });
+
+    afterEach(() => {
+        lthelper.destroy()
+    });
+
+    it('it uses settings from config file', () => {
+      expect(lthelper.ltserver).toBeDefined();
+      expect(lthelper.ltserver.process).toBeDefined();
+      expect(lthelper.ltinfo).toBeDefined();
+    });
+  });
+
+  describe('When the local jar and a non-existent config file is given', () => {
+
+    beforeEach(() => {
+      atom.config.set(
+        'linter-languagetool.languagetoolServerPath',
+        '/usr/local/Cellar/languagetool/4.5/libexec/languagetool-server.jar'
+      )
+
+      atom.config.set(
+        'linter-languagetool.configFilePath',
+        __dirname + '/test_files/sample_languagetool.txt'
+      )
+
+      waitsForPromise(() => {
+        return lthelper.init()
+      });
+    });
+
+    afterEach(() => {
+        lthelper.destroy()
+    });
+
+    it('it refuses to start the local server', () => {
+      expect(lthelper.ltserver).toBeUndefined();
+    });
+  });
 }

--- a/spec/ltserver-helper-spec.js
+++ b/spec/ltserver-helper-spec.js
@@ -26,7 +26,7 @@ if (process.platform === 'darwin') {
   describe('When the local jar is given', () => {
 
     beforeEach(() => {
-      atom.config.set('linter-languagetool.languagetoolServerPath','/usr/local/Cellar/languagetool/4.3/libexec/languagetool-server.jar')
+      atom.config.set('linter-languagetool.languagetoolServerPath','/usr/local/Cellar/languagetool/4.5/libexec/languagetool-server.jar')
       waitsForPromise(() => {
         return lthelper.init()
       });
@@ -47,7 +47,7 @@ if (process.platform === 'darwin') {
   describe('When the local jar and port is given', () => {
 
     beforeEach(() => {
-      atom.config.set('linter-languagetool.languagetoolServerPath','/usr/local/Cellar/languagetool/4.3/libexec/languagetool-server.jar')
+      atom.config.set('linter-languagetool.languagetoolServerPath','/usr/local/Cellar/languagetool/4.5/libexec/languagetool-server.jar')
       atom.config.set('linter-languagetool.languagetoolServerPort',8085)
       waitsForPromise(() => {
         return lthelper.init()

--- a/spec/test_files/sample_languagetool.cfg
+++ b/spec/test_files/sample_languagetool.cfg
@@ -1,0 +1,5 @@
+# LanguageTool configuration
+# Setting maxTextLength to a value lower than 13 causes problems with
+# internal logic of linter-languagetool plugin, as a 13 characters test string
+# is used to check if a local languagetool instance is running.
+maxTextLength=13


### PR DESCRIPTION
Closes #34

We need to pass `args` as an array to `BufferedProcess` instead of 
concatenated string for the command to correctly pick up arguments.

### Todo

- [x] Make tests pass
- [x] Add test for reading config file